### PR TITLE
Add missing sitename to parameter.yml.dist

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,3 +18,6 @@ parameters:
 
     # A secret key that's used to generate certain security-related tokens
     secret:            ThisTokenIsNotSoSecretChangeIt
+
+    # Clastic settings
+    clastic_site_name: Clastic


### PR DESCRIPTION
`clastic_site_name` was missing.
